### PR TITLE
Base Control Migration

### DIFF
--- a/samples/MauiIcons.Sample/MainPage.xaml
+++ b/samples/MauiIcons.Sample/MainPage.xaml
@@ -36,14 +36,14 @@
                 HorizontalOptions="Center" />
 
             <HorizontalStackLayout Spacing="25" HorizontalOptions="Center">
-                <!--Maui Icons Built in Controls-->
+                <!--  Icons Built in Controls -->
+                <fluent:MauiIcon Icon="Accessibility48"/>
                 <segoeFluent:MauiIcon Icon="Accounts" IconColor="Red"/>
                 <material:MauiIcon Icon="ABC" IconColor="Cyan"/>
-                <fluent:MauiIcon Icon="Accessibility48"/>
                 <fluentFilled:MauiIcon Icon="Accessibility48Filled" IconColor="BlueViolet"/>
                 <cuppertino:MauiIcon Icon="Airplane"/>
 
-                <!--Image Extension-->
+                <!-- Extension -->
                 <Image Aspect="Center" Source="{segoeFluent:Icon Icon=ActionCenterQuiet, IconColor=Yellow}"/>
                 <Image Aspect="Center" Source="{material:Icon Icon=AddRoad, IconColor=BlueViolet}"/>
                 <Image Aspect="Center" Source="{fluent:Icon Icon=AddSquare20}"/>
@@ -60,13 +60,22 @@
                 <Button Text="{cuppertino:Icon Icon=Alarm, IconColor=Blue}"/>
             </HorizontalStackLayout>
 
-            <Label Text="Material Variant" HorizontalOptions="Center"/>
+            <Label HorizontalOptions="Center">Label Based Icons</Label>
             <HorizontalStackLayout HorizontalOptions="Center">
+                <Label  Text="{material:Icon Icon=AccountCircle, IconColor=Yellow}"/>
+                <Label Text="{material:Icon Icon=AccountCircle, IconColor=BlueViolet, Variant=Outlined}"/>
+                <Label Text="{material:Icon Icon=AccountCircle, Variant=Rounded}"/>
+                <Label Text="{material:Icon Icon=AccountCircle, IconColor=DarkGreen, Variant=Sharp}"/>
+                <Label Text="{material:Icon Icon=AccountCircle, IconColor=LightBlue, Variant=TwoTone}"/>
+            </HorizontalStackLayout>
+
+            <Label Text="Material Variant" HorizontalOptions="Center"/>
+            <HorizontalStackLayout HorizontalOptions="Center" BackgroundColor="White" Padding="12,12">
                 <material:MauiIcon Icon="AccountCircle" IconColor="LightGreen"/>
                 <material:MauiIcon Icon="AccountCircle" Variant="Outlined" IconColor="Aqua"/>
                 <material:MauiIcon Icon="AccountCircle" Variant="Rounded" IconColor="Aquamarine"/>
-                <material:MauiIcon Icon="AccountCircle" Variant="Sharp" IconColor="Beige"/>
-                <material:MauiIcon Icon="AccountCircle" Variant="TwoTone" IconColor="Yellow"/>
+                <material:MauiIcon Icon="AccountCircle" Variant="Sharp" IconColor="Blue"/>
+                <material:MauiIcon Icon="AccountCircle" Variant="TwoTone"/>
             </HorizontalStackLayout>
 
             <Label Text="Material Variant Extension" HorizontalOptions="Center"/>
@@ -83,7 +92,7 @@
                 <Button Text="{material:Icon Home, IconColor=BlueViolet, IconSize=Large, Variant=Outlined}"/>
                 <Button Text="{material:Icon Home, IconColor=BlueViolet, IconSize=Large, Variant=Rounded}"/>
                 <Button Text="{material:Icon Icon=Home, IconColor=BlueViolet, IconSize=Large, Variant=Sharp}"/>
-                <Button Text="{material:Icon Icon=Home, IconColor=Blue, Variant=TwoTone}"/>
+                <Button Text="{material:Icon Icon=AccountCircle, IconColor=Blue, Variant=TwoTone}"/>
             </HorizontalStackLayout>
 
             <Label Text="Material Variant Code Behind" HorizontalOptions="Center"/>

--- a/src/MauiIcons.Core/Extensions/BaseIconExtension.cs
+++ b/src/MauiIcons.Core/Extensions/BaseIconExtension.cs
@@ -44,26 +44,31 @@ public abstract class BaseIconExtension : IMarkupExtension<object>
                 button.FontFamily = AssignDefaultFontFamily();
                 button.TextColor = IconColor ?? ThemeHelper.SetDefaultIconColor();
                 button.FontSize = IconSize;
+                button.FontAutoScalingEnabled = IconAutoScaling;
                 break;
             case Label label:
                 label.FontFamily = AssignDefaultFontFamily();
                 label.TextColor = IconColor ?? ThemeHelper.SetDefaultIconColor();
                 label.FontSize = IconSize;
+                label.FontAutoScalingEnabled = IconAutoScaling;
                 break;
             case Entry entry:
                 entry.FontFamily = AssignDefaultFontFamily();
                 entry.TextColor = IconColor ?? ThemeHelper.SetDefaultIconColor();
                 entry.FontSize = IconSize;
+                entry.FontAutoScalingEnabled = IconAutoScaling;
                 break;
             case Editor editor:
                 editor.FontFamily = AssignDefaultFontFamily();
                 editor.TextColor = IconColor ?? ThemeHelper.SetDefaultIconColor();
                 editor.FontSize = IconSize;
+                editor.FontAutoScalingEnabled = IconAutoScaling;
                 break;
             case SearchBar searchBar:
                 searchBar.FontFamily = AssignDefaultFontFamily();
                 searchBar.TextColor = IconColor ?? ThemeHelper.SetDefaultIconColor();
                 searchBar.FontSize = IconSize;
+                searchBar.FontAutoScalingEnabled = IconAutoScaling;
                 break;
             default:
                 throw new NotSupportedException($"Icon Extension using Text Doesn't Support this Control {targetObject}");

--- a/src/MauiIcons.Core/MauiIcons.Core.csproj
+++ b/src/MauiIcons.Core/MauiIcons.Core.csproj
@@ -39,7 +39,7 @@
 		<Product>$(AssemblyName) ($(TargetFramework))</Product>
 		<AssemblyVersion>1.2.0.0</AssemblyVersion>
 		<AssemblyFileVersion>1.2.0.0</AssemblyFileVersion>
-		<Version>1.2.0-pre</Version>
+		<Version>1.2.0-pre1</Version>
 		<PackageVersion>$(Version)$(VersionSuffix)</PackageVersion>
 		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 		<PackageTags>MauiIcons,Icon,Dotnet,Maui,Icons,Icon,MauiIcon,iOSIcon,AndroidIcon,Material,Fluent,Cuppertino,SegoeFluent</PackageTags>

--- a/src/MauiIcons.Cupertino/Controls/MauiIcon.cs
+++ b/src/MauiIcons.Cupertino/Controls/MauiIcon.cs
@@ -5,7 +5,7 @@ public sealed class MauiIcon : BaseMauiIcon
 {
     public new CupertinoIcons? Icon
     {
-        get => (CupertinoIcons?)GetValue(IconProperty);
-        set => SetValue(IconProperty, value);
+        get => (CupertinoIcons?)base.Icon;
+        set => base.Icon = value;
     }
 }

--- a/src/MauiIcons.Cupertino/MauiIcons.Cupertino.csproj
+++ b/src/MauiIcons.Cupertino/MauiIcons.Cupertino.csproj
@@ -39,7 +39,7 @@
 		<Product>$(AssemblyName) ($(TargetFramework))</Product>
 		<AssemblyVersion>1.2.0.0</AssemblyVersion>
 		<AssemblyFileVersion>1.2.0.0</AssemblyFileVersion>
-		<Version>1.2.0</Version>
+		<Version>1.2.0-pre1</Version>
 		<PackageVersion>$(Version)$(VersionSuffix)</PackageVersion>
 		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 		<PackageTags>MauiIcons,Icon,Cuppertino,Dotnet,Maui,Icons,Icon,MauiIcon,iOSIcon,AndroidIcon,Material,Fluent,SegoeFluent</PackageTags>

--- a/src/MauiIcons.Fluent/Controls/MauiIcon.cs
+++ b/src/MauiIcons.Fluent/Controls/MauiIcon.cs
@@ -5,7 +5,7 @@ public sealed class MauiIcon : BaseMauiIcon
 {
     public new FluentIcons? Icon 
     {
-        get => (FluentIcons?)GetValue(IconProperty); 
-        set => SetValue(IconProperty, value);
+        get => (FluentIcons?)base.Icon; 
+        set => base.Icon = value;
     }
 }

--- a/src/MauiIcons.Fluent/MauiIcons.Fluent.csproj
+++ b/src/MauiIcons.Fluent/MauiIcons.Fluent.csproj
@@ -39,7 +39,7 @@
 		<Product>$(AssemblyName) ($(TargetFramework))</Product>
 		<AssemblyVersion>1.2.0.0</AssemblyVersion>
 		<AssemblyFileVersion>1.2.0.0</AssemblyFileVersion>
-		<Version>1.2.0</Version>
+		<Version>1.2.0-pre1</Version>
 		<PackageVersion>$(Version)$(VersionSuffix)</PackageVersion>
 		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 		<PackageTags>MauiIcons,Icon,Dotnet,Maui,Icons,Icon,MauiIcon,iOSIcon,AndroidIcon,Material,Fluent,Cuppertino,SegoeFluent</PackageTags>

--- a/src/MauiIcons.FluentFilled/Controls/MauiIcon.cs
+++ b/src/MauiIcons.FluentFilled/Controls/MauiIcon.cs
@@ -1,12 +1,11 @@
 ﻿using MauiIcons.Core;
-using MauiIcons.FluentFilled.Common;
 
 namespace MauiIcons.FluentFilled;
 public sealed class MauiIcon : BaseMauiIcon
 {
     public new FluentFilledIcons? Icon
     {
-        get => (FluentFilledIcons?)GetValue(IconProperty);
-        set => SetValue(IconProperty, value);
+        get => (FluentFilledIcons?)base.Icon;
+        set => base.Icon = value;
     }
 }

--- a/src/MauiIcons.FluentFilled/MauiIcons.FluentFilled.csproj
+++ b/src/MauiIcons.FluentFilled/MauiIcons.FluentFilled.csproj
@@ -39,7 +39,7 @@
 		<Product>$(AssemblyName) ($(TargetFramework))</Product>
 		<AssemblyVersion>1.2.0.0</AssemblyVersion>
 		<AssemblyFileVersion>1.2.0.0</AssemblyFileVersion>
-		<Version>1.2.0</Version>
+		<Version>1.2.0-pre1</Version>
 		<PackageVersion>$(Version)$(VersionSuffix)</PackageVersion>
 		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 		<PackageTags>MauiIcons,Icon,Dotnet,Maui,Icons,Icon,MauiIcon,iOSIcon,AndroidIcon,Material,Fluent,FluentFilled,Cuppertino,SegoeFluent</PackageTags>

--- a/src/MauiIcons.Material/Controls/MauiIcon.cs
+++ b/src/MauiIcons.Material/Controls/MauiIcon.cs
@@ -5,13 +5,13 @@ public sealed class MauiIcon : BaseMauiIconVariant
 {
     public new MaterialIcons? Icon
     {
-        get => (MaterialIcons?)GetValue(IconProperty);
-        set => SetValue(IconProperty, value);
+        get => (MaterialIcons?)base.Icon;
+        set => base.Icon = value;
     }
     public new MaterialVariant Variant
     {
-        get => (MaterialVariant)GetValue(VariantProperty);
-        set => SetValue(VariantProperty, value);
+        get => (MaterialVariant)base.Variant;
+        set => base.Variant = value;
     }
     protected override Dictionary<Enum, string> VariantType { get; set; } = new Dictionary<Enum, string>()
     {

--- a/src/MauiIcons.Material/MauiIcons.Material.csproj
+++ b/src/MauiIcons.Material/MauiIcons.Material.csproj
@@ -39,7 +39,7 @@
 		<Product>$(AssemblyName) ($(TargetFramework))</Product>
 		<AssemblyVersion>1.2.0.0</AssemblyVersion>
 		<AssemblyFileVersion>1.2.0.0</AssemblyFileVersion>
-		<Version>1.2.0-pre</Version>
+		<Version>1.2.0-pre1</Version>
 		<PackageVersion>$(Version)$(VersionSuffix)</PackageVersion>
 		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 		<PackageTags>MauiIcons,Icon,Dotnet,Maui,Icons,Icon,MauiIcon,iOSIcon,AndroidIcon,Material,Fluent,Cuppertino,SegoeFluent</PackageTags>

--- a/src/MauiIcons.SegoeFluent/Controls/MauiIcon.cs
+++ b/src/MauiIcons.SegoeFluent/Controls/MauiIcon.cs
@@ -5,7 +5,7 @@ public sealed class MauiIcon : BaseMauiIcon
 {
     public new SegoeFluentIcons? Icon 
     {
-        get => (SegoeFluentIcons?)GetValue(IconProperty); 
-        set => SetValue(IconProperty, value);
+        get => (SegoeFluentIcons?)base.Icon; 
+        set => base.Icon = value;
     }
 }

--- a/src/MauiIcons.SegoeFluent/MauiIcons.SegoeFluent.csproj
+++ b/src/MauiIcons.SegoeFluent/MauiIcons.SegoeFluent.csproj
@@ -39,7 +39,7 @@
 		<Product>$(AssemblyName) ($(TargetFramework))</Product>
 		<AssemblyVersion>1.2.0.0</AssemblyVersion>
 		<AssemblyFileVersion>1.2.0.0</AssemblyFileVersion>
-		<Version>1.2.0</Version>
+		<Version>1.2.0-pre1</Version>
 		<PackageVersion>$(Version)$(VersionSuffix)</PackageVersion>
 		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 		<PackageTags>MauiIcons,Icon,Dotnet,Maui,Icons,Icon,MauiIcon,iOSIcon,AndroidIcon,Material,Fluent,Cuppertino,SegoeFluent</PackageTags>


### PR DESCRIPTION
Base Control Migration to Native Text Control Instead of Image Source, This PR would Saves CPU Cycles and Memory Usage on Converting Unicode to ImageSource Every Time the Icon Displays